### PR TITLE
Cambiado fichero cluster y añadido montaje como ejemplo

### DIFF
--- a/configuracion
+++ b/configuracion
@@ -1,0 +1,1 @@
+10.2.2.5 montaje montaje.conf

--- a/configurar_cluster.sh
+++ b/configurar_cluster.sh
@@ -1,4 +1,4 @@
-    #!/bin/bash
+#!/bin/bash
 if test $# -ne 1; #Comprueba que se le pasa el parametro adecuado
 then
     >&2 echo "Modo de empleo: configurar_cluster.sh fichero_configuracion"
@@ -27,5 +27,69 @@ do
         fi
 
     fi
+
+done < $1
+
+#Hacemos los checks de sintaxis de los ficheros de perfil de servicio en el nodo de control 
+#y ejecutamos los scripts de configuracion en remoto recogiendo resultados
+while read linea
+do
+
+    #Saltamos las lineas en blanco y las que empiecen por '#'
+    if [[ "$linea" = "#"* || -z $linea ]]; then 
+        true;
+    else
+
+    HOST=`echo $linea | awk '{ printf $1 }'`;
+    SERVICIO=`echo $linea | awk '{ printf $2 }'`;
+    CONFILE=`echo $linea | awk '{ printf $3 }'`;
+
+    #Comprobamos que el servicio existe
+    case "$SERVICIO" in
+    montaje);;
+    raid);;
+    lvm);;
+    nis_server) ;;
+    nis_client) ;;
+    nfs_server) ;;
+    nfs_client) ;;
+    backup_server) ;;
+    backup_client) ;;
+    *)
+        >&2 echo "El servicio $SERVICIO no es configurable, especifique un servicio existente";
+        exit 3;
+    ;;
+    esac
+    
+    #Copiamos el fichero de configuracion al host
+    scp "$CONFILE" practicas@"$HOST":/tmp;
+
+    #Recogemos el resultado
+    if [ $? -ne 0 ]; then 
+    >&2 echo "Error copiando el fichero de configuracion del servicio $SERVICIO a $HOST\n";
+    exit 4;
+    fi
+
+    #Ejecutamos en remoto
+    ssh practicas@"$HOST" 'bash -s' < "$SERVICIO".sh /tmp/"$CONFILE";
+
+    #Recogemos resultado
+    if [ $? -ne 0 ]; then 
+    >&2 echo "Error ejecutando el script de configuracion del servicio $SERVICIO remotamente en $HOST\n";
+    exit 5;
+    fi
+
+    #Eliminamos el fichero de configuracion
+    ssh practicas@"$HOST" rm -rf /tmp/"$CONFILE";
+
+    #Recogemos resultado
+    if [ $? -ne 0 ]; then 
+    >&2 echo "Error eliminando el fichero de configuracion del servicio $SERVICIO remotamente en $HOST\n";
+    exit 6;
+    fi
+
+    fi
+    
+    
 
 done < $1

--- a/lvm.sh
+++ b/lvm.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
-if test $# -ne 2; #Comprueba que se le pasa el parametro adecuado
-then
-    >&2 echo "Modo de empleo: configurar_cluster.sh [Opciones] fichero_configuracion"
-    exit 1;
 
-elif [[ $1 = "lvm" ]]; then #Comprueba que sea el servicio lvm
-aux=1;
-while read linea$aux #Lee las lineas del servcio
-do
-    aux=$(($aux+1));
-done < $2
 
 echo "Antes de usar el comando lvm, se comprobará que está instalado."
 which lvm > /dev/null 2>&1;
@@ -40,7 +30,7 @@ mem_disponible=0; #Suma de la memoria disponible en las particiones de el/los di
 while read linea$aux #Lee las tres lineas del servcio
 do
     aux=$(($aux+1));
-done < $2
+done < $1
 
 if [ $aux -lt 3 ] #Comprueba que el fichero leido está compuesto de al menos 3 líneas.
 then
@@ -57,7 +47,7 @@ do
         mem_total=$(($mem_total+$aux));
     fi
     iterador=$(($iterador+1));
-done < $2
+done < $1
 
 echo "El espacio requerido en total es $mem_total GB"
 
@@ -98,7 +88,7 @@ echo "Todas las particiones han sido borradas y los volumenes fisicos creados."
 echo "Construyendo volumen físico $linea1"
 vgcreate $linea1 $linea2 > /dev/null 2>&1;
 
-aux=$(echo $2 | wc -l);
+aux=$(echo $1 | wc -l);
 #Este bucle recorre las lineas del fichero que continen la configuración de los LV
 while read lin #Lee las lineas del servcio
 do
@@ -110,6 +100,6 @@ do
         lvcreate -L $tam -n $nombre $linea1 > /dev/null 2>&1;
     fi
     aux=$(($aux+1));
-done < $2
+done < $1
 
 fi

--- a/montaje.conf
+++ b/montaje.conf
@@ -1,0 +1,2 @@
+/dev/sda1
+/home

--- a/montaje.sh
+++ b/montaje.sh
@@ -1,35 +1,33 @@
-if test $# -ne 2; #Comprueba que se le pasa el parametro adecuado
-then
-    >&2 echo "Modo de empleo: configurar_cluster.sh [Opciones] fichero_configuracion"
-    exit 1;
-elif [[ $1 = "mount" ]]; then
+#!/bin/bash
 
-    aux=1;
-    while read linea$aux
-    do
-        aux=$(($aux+1));
-    done < $2
+aux=1;
+while read linea$aux
+do
+    aux=$(($aux+1));
+done < $1
 
-    echo "Acediendo al punto de montaje $linea2";
-    cd "$linea2" > /dev/null 2>&1;
+echo "Acediendo al punto de montaje $linea2";
+cd "$linea2" > /dev/null 2>&1;
 
-    if [[ $? != 0 ]]; then #Comprueba que se ha accedido al directorio, sino se crea
+if [[ $? != 0 ]]; then #Comprueba que se ha accedido al directorio, sino se crea
     echo "Directorio no existe, se va a crear $linea2"
     mkdir -p "$linea2";
 
     if [[ $? != 0 ]]; then #Comprueba que se ha creado el directorio correctamente
-    echo "Directorio no creado, prueba con un nombre válido"
-    exit 1;
+        echo "Directorio no creado, prueba con un nombre válido"
+        exit 1;
+    fi
 else
     echo "Directorio: $linea2, ha sido creado."
     echo "Se va a acceder a él."
     cd "$linea2";
-fi
+
 fi
 echo "pwd: $(pwd)"
 echo "Montando $linea1 en $linea2"
-mount "$linea1" "$linea2"
+sudo mount "$linea1" "$linea2" -t auto
+#Obtenemos el tipo del sistema de ficheros del dispositivo
+tipo=`df -Th | grep $linea1 | awk '{printf $2}'`
 echo "Se va a modificar el fichero /etc/fstab, para que se monte el disco cada vez que arranque el sistema."
-echo "$liena1    $linea2      ext4    auto    0         0" >> /etc/fstab
+sudo echo "$linea1    $linea2      $tipo    auto    0         0" | sudo tee -a /etc/fstab;
 
-fi

--- a/raid.sh
+++ b/raid.sh
@@ -1,15 +1,10 @@
-if test $# -ne 2; #Comprueba que se le pasa el parametro adecuado
-then
-    >&2 echo "Modo de empleo: configurar_cluster.sh [Opciones] fichero_configuracion"
-    exit 1;
+#!/bin/bash
 
-elif [[ $1 = "raid" ]]; then #Comprueba que sea el servicio raid
-    aux=1;
-    while read linea$aux #Lee las tres lineas del servcio
-    do
-        aux=$(($aux+1));
-    done < $2
-fi
+aux=1;
+while read linea$aux #Lee las tres lineas del servcio
+do
+    aux=$(($aux+1));
+done < $1
 
 echo "Instalando el programa mdadm"
 export  DEBIAN_FRONTEND=noninteractive;  # Esto bloquea toda la interacción con el ususario durante la instalación
@@ -21,7 +16,7 @@ apt-get install -y mdadm #> /dev/null 2>&1  #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 #fi
 
 echo "mdamd ha sido instalado satisfactoriamente."
-echo "Montando raid especificado en el fichero $2"
+echo "Montando raid especificado en el fichero $1"
 
 mdadm --create "$linea1" --metadata=0.90 --level="$linea2" --raid-devices=$(echo $linea3 | wc -w)  $linea3 > /dev/null 2>&1; #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!Tambíen pide confirmación con yes, hay que evitarlos
 


### PR DESCRIPTION
Echale un ojo, he eliminado las lineas que ya compruebo y ajustado el fichero de montaje, no se si te funcionara el de raid pero creo que estabas ejecutando mal. Me refiero a que no se pasa el fichero de config de servicio en la ejecucion si no en el fichero. 
"configurar_cluster.sh fichconfig" y luego dentro de fichconfig "IPMaquina nombreservicio fichconfigservicio". Aun asi luego le echamos un ojo